### PR TITLE
Split display of main commit message and description

### DIFF
--- a/sphinx_git.py
+++ b/sphinx_git.py
@@ -29,17 +29,24 @@ class GitChangelog(Directive):
         l = nodes.bullet_list()
         for commit in list(commits)[:10]:
             date_str = datetime.fromtimestamp(commit.authored_date)
+            if '\n' in commit.message:
+                message, detailed_message = commit.message.split('\n', 1)
+            else:
+                message = commit.message
+                detailed_message = None
+
             item = nodes.list_item()
             item += [
-                nodes.strong(text=commit.message),
+                nodes.strong(text=message),
                 nodes.inline(text=" by "),
                 nodes.emphasis(text=str(commit.author)),
                 nodes.inline(text=" at "),
                 nodes.emphasis(text=str(date_str))
             ]
+            if detailed_message:
+                item.append(nodes.caption(text=detailed_message.strip()))
             l.append(item)
         return [l]
-
 
 
 def setup(app):

--- a/tests/test_git_changelog.py
+++ b/tests/test_git_changelog.py
@@ -82,6 +82,18 @@ class TestWithRepository(TempDirTestCase):
         assert_less_equal(before, timestamp)
         assert_greater(after, timestamp)
 
+    def test_single_commit_multiple_lines(self):
+        self.repo.index.commit('my root commit\n\nadditional information')
+        nodes = self.changelog.run()
+        list_markup = BeautifulStoneSoup(str(nodes[0]))
+        item = list_markup.bullet_list.list_item
+        children = list(item.childGenerator())
+        assert_equal(6, len(children))
+        assert_equal('my root commit', children[0].text)
+        assert_equal('Test User', children[2].text)
+        assert_equal(str(children[5]),
+                     '<caption>additional information</caption>')
+
     def test_more_than_ten_commits(self):
         for n in range(15):
             self.repo.index.commit('commit #{0}'.format(n))


### PR DESCRIPTION
This will allow messages to be split into the main message and the more descriptive message.
