### PR TITLE
Add search_parent_directories=True to Repo creation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     version=__version__,
     author='Daniel Watkins',
     author_email='daniel@daniel-watkins.co.uk',
-    install_requires=['sphinx', 'GitPython>=0.3.2.RC1'],
+    install_requires=['sphinx', 'GitPython>=0.3.6'],
     url="https://github.com/OddBloke/sphinx-git",
     packages=['sphinx_git'],
 )

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -21,6 +21,7 @@ from git import Repo
 from sphinx.util.compat import Directive
 
 
+# pylint: disable=too-few-public-methods
 class GitChangelog(Directive):
 
     option_spec = {
@@ -47,7 +48,7 @@ class GitChangelog(Directive):
 
     def _find_repo(self):
         env = self.state.document.settings.env
-        repo = Repo(env.srcdir)
+        repo = Repo(env.srcdir, search_parent_directories=True)
         return repo
 
     def _filter_commits(self, repo):

--- a/tests/test_git_changelog.py
+++ b/tests/test_git_changelog.py
@@ -181,14 +181,16 @@ class TestWithRepository(TempDirTestCase):
         assert_in('after tag', second_element.text)
 
     def test_warning_given_if_rev_list_and_revisions_both_given(self):
-        self.changelog.options = {'rev-list': 'foo..', 'revisions': 12}
+        self.repo.index.commit('a commit')
+        self.changelog.options = {'rev-list': 'HEAD', 'revisions': 12}
         nodes = self.changelog.run()
         assert_equal(
             1, self.changelog.state.document.reporter.warning.call_count
         )
 
     def test_line_number_displayed_in_multiple_option_warning(self):
-        self.changelog.options = {'rev-list': 'foo..', 'revisions': 12}
+        self.repo.index.commit('a commit')
+        self.changelog.options = {'rev-list': 'HEAD', 'revisions': 12}
         nodes = self.changelog.run()
         document_reporter = self.changelog.state.document.reporter
         assert_equal(


### PR DESCRIPTION
Fixes #18 (error with new version of GitPython).