### PR TITLE
Remove unnecessary requirements from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,3 @@ mock
 nose
 pep8
 pylint
-travis-solo
-
--e .


### PR DESCRIPTION
travis-solo isn't needed any more, because we just run tox in travis.

"-e ." isn't needed any more because tox does an install itself.