### PR TITLE
Added rendering for submodules

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -30,6 +30,13 @@ underscore)::
 
     extensions = ['sphinx_git']
 
+There is one global switch that changes the behavior of sphinx-git when
+processing git submodules. Default behavior is that sphing-git renders
+the git history of the sphinx directory. If you want sphinx-git to
+render the history of the submodule instead you can add::
+
+    git_respect_submodules = True
+
 Add A git Changelog To Your Project
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -28,9 +28,9 @@ class GitDirectiveBase(Directive):
     def _find_repo(self):
         env = self.state.document.settings.env
         if env.config.git_respect_submodules:
-           srcdir = env.doc2path(env.docname)
+            srcdir = env.doc2path(env.docname)
         else:
-           srcdir = env.srcdir
+            srcdir = env.srcdir
         return Repo(srcdir, search_parent_directories=True)
 
 

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -27,8 +27,11 @@ from sphinx.util.compat import Directive
 class GitDirectiveBase(Directive):
     def _find_repo(self):
         env = self.state.document.settings.env
-        repo = Repo(env.srcdir, search_parent_directories=True)
-        return repo
+        if env.config.git_respect_submodules:
+           srcdir = env.doc2path(env.docname)
+        else:
+           srcdir = env.srcdir
+        return Repo(srcdir, search_parent_directories=True)
 
 
 # pylint: disable=too-few-public-methods
@@ -195,3 +198,4 @@ class GitChangelog(GitDirectiveBase):
 def setup(app):
     app.add_directive('git_changelog', GitChangelog)
     app.add_directive('git_commit_detail', GitCommitDetail)
+    app.add_config_value('git_respect_submodules', False, 'env')

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -21,14 +21,14 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from git import Repo
 from sphinx.util.compat import Directive
-
+from os import path
 
 # pylint: disable=too-few-public-methods, abstract-method
 class GitDirectiveBase(Directive):
     def _find_repo(self):
         env = self.state.document.settings.env
         if env.config.git_respect_submodules:
-            srcdir = env.doc2path(env.docname)
+            srcdir = path.dirname(env.doc2path(env.docname, base=True))
         else:
             srcdir = env.srcdir
         return Repo(srcdir, search_parent_directories=True)


### PR DESCRIPTION
With the global switch `git_respect_submodules = True` it is possible to have the history log of every added submodule rendered. This is useful if you are compiling a documentation from several different git repositories.