### PR TITLE
Add options to modify changelog output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@ dev
 ---
 
 * Add filename_filter argument to git_changelog (Emmanuelle Delescolle) 
+* Add options to hide author, date and/or detail to git_changelog
+  (Peter Mosmans)
 
 v10.0.0
 -------

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -184,14 +184,13 @@ class GitChangelog(GitDirectiveBase):
             if not self.options.get('hide_date'):
                 item += [nodes.inline(text=" at "),
                          nodes.emphasis(text=str(date_str))]
-            if detailed_message:
-                if not self.options.get('hide_details'):
-                    detailed_message = detailed_message.strip()
-                    if self.options.get('detailed-message-pre', False):
-                        item.append(
-                            nodes.literal_block(text=detailed_message))
-                    else:
-                        item.append(nodes.paragraph(text=detailed_message))
+            if detailed_message and not self.options.get('hide_details'):
+                detailed_message = detailed_message.strip()
+                if self.options.get('detailed-message-pre', False):
+                    item.append(
+                        nodes.literal_block(text=detailed_message))
+                else:
+                    item.append(nodes.paragraph(text=detailed_message))
             list_node.append(item)
         return [list_node]
 

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -117,6 +117,9 @@ class GitChangelog(GitDirectiveBase):
         'rev-list': six.text_type,
         'detailed-message-pre': bool,
         'filename_filter': six.text_type,
+        'hide_author': bool,
+        'hide_date': bool,
+        'hide_details': bool,
     }
 
     def run(self):
@@ -174,20 +177,21 @@ class GitChangelog(GitDirectiveBase):
                 detailed_message = None
 
             item = nodes.list_item()
-            item += [
-                nodes.strong(text=message),
-                nodes.inline(text=" by "),
-                nodes.emphasis(text=six.text_type(commit.author)),
-                nodes.inline(text=" at "),
-                nodes.emphasis(text=str(date_str))
-            ]
+            item += nodes.strong(text=message)
+            if not self.options.get('hide_author'):
+                item += [nodes.inline(text=" by "),
+                         nodes.emphasis(text=six.text_type(commit.author))]
+            if not self.options.get('hide_date'):
+                item += [nodes.inline(text=" at "),
+                         nodes.emphasis(text=str(date_str))]
             if detailed_message:
-                detailed_message = detailed_message.strip()
-                if self.options.get('detailed-message-pre', False):
-                    item.append(
-                        nodes.literal_block(text=detailed_message))
-                else:
-                    item.append(nodes.paragraph(text=detailed_message))
+                if not self.options.get('hide_details'):
+                    detailed_message = detailed_message.strip()
+                    if self.options.get('detailed-message-pre', False):
+                        item.append(
+                            nodes.literal_block(text=detailed_message))
+                    else:
+                        item.append(nodes.paragraph(text=detailed_message))
             list_node.append(item)
         return [list_node]
 

--- a/tests/test_git_changelog.py
+++ b/tests/test_git_changelog.py
@@ -227,3 +227,42 @@ class TestWithRepository(ChangelogTestCase):
 
         l = list_markup.bullet_list
         assert_equal(2, len(l.findAll('list_item')), nodes)
+
+    def test_single_commit_hide_details(self):
+        self.repo.index.commit(
+            'Another commit\n\nToo much information'
+        )
+        self.changelog.options = {'hide_details': True}
+        nodes = self.changelog.run()
+        list_markup = BeautifulSoup(str(nodes[0]), features='xml')
+        item = list_markup.bullet_list.list_item
+        children = list(item.childGenerator())
+        assert_equal(5, len(children))
+        assert_equal('Another commit', children[0].text)
+        assert_equal('Test User', children[2].text)
+
+    def test_single_commit_message_hide_author(self):
+        self.repo.index.commit('Yet another commit')
+        self.changelog.options = {'hide_author': True}
+        nodes = self.changelog.run()
+        list_markup = BeautifulSoup(str(nodes[0]), features='xml')
+        item = list_markup.bullet_list.list_item
+        children = list(item.childGenerator())
+        print(children)
+        assert_equal(3, len(children))
+        assert_equal('Yet another commit', children[0].text)
+        assert_not_in(' by Test User', children[1].text)
+        assert_in(' at ', children[1].text)
+
+    def test_single_commit_message_hide_date(self):
+        self.repo.index.commit('Yet yet another commit')
+        self.changelog.options = {'hide_date': True}
+        nodes = self.changelog.run()
+        list_markup = BeautifulSoup(str(nodes[0]), features='xml')
+        item = list_markup.bullet_list.list_item
+        children = list(item.childGenerator())
+        print(children)
+        assert_equal(3, len(children))
+        assert_equal('Yet yet another commit', children[0].text)
+        assert_not_in(' at ', children[1].text)
+        assert_in(' by ', children[1].text)


### PR DESCRIPTION
Set the `hide_author` argument to True to hide the commit user, e.g. `:hide_author: True`.
Set the `hide_date` argument to True to hide the commit date, e.g. `:hide_date: True`.
Set the `hide_details` argument to True to hide the commit message and only show
the commit title, e.g. `:hide_author: True`.