### PR TITLE
Default commit message in plain text (not strong) and documentation fix

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -125,6 +125,59 @@ becomes:
     :doc:`Patches welcome! <contributing>`
 
 
+Hiding author name from change lines
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you need clean output without author's names in changelog,
+then you can specify this preference using the ``:hide_author: True``
+argument, for example:
+
+    .. git_changelog::
+        :hide_author: 1
+
+.. _the man page: https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html
+
+.. rubric:: Footnotes
+
+.. [#patches]
+    :doc:`Patches welcome! <contributing>`
+
+
+Hiding commit date from change lines
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you need clean output without commit dates in changelog,
+then you can specify this preference using the ``:hide_date: True``
+argument, for example:
+
+    .. git_changelog::
+        :hide_date: True
+
+.. _the man page: https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html
+
+.. rubric:: Footnotes
+
+.. [#patches]
+    :doc:`Patches welcome! <contributing>`
+
+
+Strong commit message text
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can format commit message text with bold by using
+the ``:detailed-message-strong: True`` argument, for example:
+
+    .. git_changelog::
+        :detailed-message-strong: True
+
+.. _the man page: https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html
+
+.. rubric:: Footnotes
+
+.. [#patches]
+    :doc:`Patches welcome! <contributing>`
+
+
 git_commit_detail Directive
 ---------------------------
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -135,13 +135,6 @@ argument, for example:
     .. git_changelog::
         :hide_author: 1
 
-.. _the man page: https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html
-
-.. rubric:: Footnotes
-
-.. [#patches]
-    :doc:`Patches welcome! <contributing>`
-
 
 Hiding commit date from change lines
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -153,29 +146,16 @@ argument, for example:
     .. git_changelog::
         :hide_date: True
 
-.. _the man page: https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html
-
-.. rubric:: Footnotes
-
-.. [#patches]
-    :doc:`Patches welcome! <contributing>`
-
 
 Strong commit message text
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can format commit message text with bold by using
-the ``:detailed-message-strong: True`` argument, for example:
+Commit message formatted with bold text by default.
+Use ``:detailed-message-strong: False`` argument if you prefer regular font,
+for example:
 
     .. git_changelog::
-        :detailed-message-strong: True
-
-.. _the man page: https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html
-
-.. rubric:: Footnotes
-
-.. [#patches]
-    :doc:`Patches welcome! <contributing>`
+        :detailed-message-strong: False
 
 
 git_commit_detail Directive

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -113,6 +113,7 @@ class GitChangelog(GitDirectiveBase):
         'revisions': directives.nonnegative_int,
         'rev-list': six.text_type,
         'detailed-message-pre': bool,
+        'detailed-message-strong': bool,
         'filename_filter': six.text_type,
         'hide_author': bool,
         'hide_date': bool,
@@ -175,7 +176,12 @@ class GitChangelog(GitDirectiveBase):
                 detailed_message = None
 
             item = nodes.list_item()
-            item += nodes.inline(text=message)
+            # choose detailed message style by detailed-message-strong option
+            if self.options.get('detailed-message-strong', False):
+                item += nodes.strong(text=message)
+            else:
+                item += nodes.inline(text=message)
+
             if not self.options.get('hide_author'):
                 item += [nodes.inline(text=" by "),
                          nodes.emphasis(text=six.text_type(commit.author))]

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -175,7 +175,7 @@ class GitChangelog(GitDirectiveBase):
                 detailed_message = None
 
             item = nodes.list_item()
-            item += nodes.strong(text=message)
+            item += nodes.inline(text=message)
             if not self.options.get('hide_author'):
                 item += [nodes.inline(text=" by "),
                          nodes.emphasis(text=six.text_type(commit.author))]

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -177,7 +177,7 @@ class GitChangelog(GitDirectiveBase):
 
             item = nodes.list_item()
             # choose detailed message style by detailed-message-strong option
-            if self.options.get('detailed-message-strong', False):
+            if self.options.get('detailed-message-strong', True):
                 item += nodes.strong(text=message)
             else:
                 item += nodes.inline(text=message)


### PR DESCRIPTION
Made simple change to get commit message in plain text instead of strong and push changes into documentation as well