### PR TITLE
Add detailed-message-style option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 dev
 ---
 
-*
+* Add detailed-message-style option to specify the style of details.
+  (amedama41)
 
 v11.0.0
 -------

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -99,23 +99,59 @@ will produce the list of commits that modified documentation content.
     selected (number of) revisions.
 
 
-Preformatted Output for Detailed Messages
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Changing Detailed Messages Output Style
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you would prefer for the detailed commit messages to be output as
-preformatted text (e.g. if you include code samples in your commit messages),
-then you can specify this preference using the ``:detailed-message-pre:``
-argument. So::
+non plain text format, then you can specify the style using the
+``detailed-message-style`` argument. The styles you can specify are 'pre',
+'rst', or, 'md'.
+
+If you would prefer for the messages to be output as preformatted text
+(e.g. if you include code samples in your commit messages),
+then you can specify 'pre' (This is same as specifying deprecated
+``detailed-message-pre``). So::
 
     .. git_changelog::
         :rev-list: 3669419^..3669419
-        :detailed-message-pre: True
+        :detailed-message-style: pre
 
 becomes:
 
     .. git_changelog::
         :rev-list: 3669419^..3669419
-        :detailed-message-pre: True
+        :detailed-message-style: pre
+
+If you would prefer for the messages to be parsed as reStructuredText,
+then you can specify 'rst'. So::
+
+    .. git_changelog::
+        :rev-list: d888873^..d888873
+        :detailed-message-style: rst
+
+becomes:
+
+    .. git_changelog::
+        :rev-list: d888873^..d888873
+        :detailed-message-style: rst
+
+If you would prefer for the messages to be parsed as Markdown (CommonMark),
+then you can specify 'md'. So::
+
+    .. git_changelog::
+        :rev-list: 0de9cd1^..0de9cd1
+        :detailed-message-style: md
+
+becomes:
+
+    .. git_changelog::
+        :rev-list: 0de9cd1^..0de9cd1
+        :detailed-message-style: md
+
+.. note::
+
+   The feature to output the messages as Markdown requires recommonmark package.
+   recommonmark is enable to be installed by pip.
 
 .. _the man page: https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html
 

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -151,7 +151,13 @@ becomes:
 .. note::
 
    The feature to output the messages as Markdown requires recommonmark package.
-   recommonmark is enable to be installed by pip.
+   recommonmark is enable to be installed by pip::
+
+       pip install recommonmark
+
+   You can also install sphinx-git with recommonmark simultaneously::
+
+       pip install sphinx-git[markdown]
 
 .. _the man page: https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mock
 nose
 pycodestyle
 pylint
+recommonmark

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setup(
     author='Daniel Watkins',
     author_email='daniel@daniel-watkins.co.uk',
     install_requires=['six', 'sphinx', 'GitPython>=0.3.6'],
+    extras_require={
+        'markdown': ['recommonmark>=0.4.0'],
+    },
     url="https://github.com/OddBloke/sphinx-git",
     packages=['sphinx_git'],
 )

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -19,6 +19,7 @@ from datetime import datetime
 import six
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
+from docutils.statemachine import StringList
 from git import Repo
 
 
@@ -106,12 +107,17 @@ class GitCommitDetail(GitDirectiveBase):
         return nodes.emphasis(text=self.commit.hexsha[:self.sha_length])
 
 
+def get_details_style(argument):
+    return directives.choice(argument, ['pre', 'rst'])
+
+
 # pylint: disable=too-few-public-methods
 class GitChangelog(GitDirectiveBase):
 
     option_spec = {
         'revisions': directives.nonnegative_int,
         'rev-list': six.text_type,
+        'detailed-message-style': get_details_style,
         'detailed-message-pre': bool,
         'detailed-message-strong': bool,
         'filename_filter': six.text_type,
@@ -128,6 +134,13 @@ class GitChangelog(GitDirectiveBase):
                 ' only rev-list.',
                 line=self.lineno
             )
+        if 'detailed-message-style' in self.options and \
+                'detailed-message-pre' in self.options:
+            self.state.document.reporter.warning(
+                'Both detailed-message-style and detailed-message-pre options'
+                ' given; proceeding using only detailed-message-style.',
+                line=self.lineno)
+
         commits = self._commits_to_display()
         markup = self._build_markup(commits)
         return markup
@@ -165,6 +178,27 @@ class GitChangelog(GitDirectiveBase):
                     break
         return filtered_commits
 
+    def _build_detailed_message(self, detailed_message):
+        detailed_message_style = self.options.get('detailed-message-style')
+        if detailed_message_style is None:
+            if self.options.get('detailed-message-pre'):
+                detailed_message_style = 'pre'
+
+        detailed_message = detailed_message.strip()
+        if detailed_message_style == 'pre':
+            return [nodes.literal_block(text=detailed_message)]
+        if detailed_message_style == 'rst':
+            try:
+                node = nodes.Element()
+                lines = detailed_message.splitlines()
+                self.state.nested_parse(StringList(lines), 0, node)
+                return node.children
+            # pylint: disable=broad-except
+            except Exception as error:
+                self.state.document.reporter.warning(
+                    'Could not parse as rst: %s' % error)
+        return [nodes.paragraph(text=detailed_message)]
+
     def _build_markup(self, commits):
         list_node = nodes.bullet_list()
         for commit in commits:
@@ -191,12 +225,7 @@ class GitChangelog(GitDirectiveBase):
                         nodes.emphasis(text=str(date_str))]
             item.append(par)
             if detailed_message and not self.options.get('hide_details'):
-                detailed_message = detailed_message.strip()
-                if self.options.get('detailed-message-pre', False):
-                    item.append(
-                        nodes.literal_block(text=detailed_message))
-                else:
-                    item.append(nodes.paragraph(text=detailed_message))
+                item.extend(self._build_detailed_message(detailed_message))
             list_node.append(item)
         return [list_node]
 

--- a/tests/test_git_changelog.py
+++ b/tests/test_git_changelog.py
@@ -173,6 +173,34 @@ class TestWithRepository(ChangelogTestCase):
             '</list_item></bullet_list>'
         )
 
+    def test_single_commit_md_style_detail_lines(self):
+        self.repo.index.commit(
+            'my root commit\n\nadditional information\n'
+            '* item1: **description1**\n'
+            '* item2: *description2*'
+        )
+        self.changelog.options.update({'detailed-message-style': 'md'})
+
+        config = self.changelog.state.document.settings.env.config
+        config.recommonmark_config = {}
+        nodes = self.changelog.run()
+        list_markup = BeautifulSoup(str(nodes[0]), features='xml')
+        item = list_markup.bullet_list.list_item
+        children = list(item.childGenerator())
+        assert_equal(3, len(children))
+        assert_equal(
+            str(children[1]),
+            '<paragraph>additional information</paragraph>'
+        )
+        assert_equal(
+            str(children[2]),
+            '<bullet_list><list_item>'
+            '<paragraph>item1: <strong>description1</strong></paragraph>'
+            '</list_item><list_item>'
+            '<paragraph>item2: <emphasis>description2</emphasis></paragraph>'
+            '</list_item></bullet_list>'
+        )
+
     def test_single_commit_pre_style_detail_lines(self):
         self.repo.index.commit(
             'my root commit\n\nadditional information\nmore info'

--- a/tests/test_git_changelog.py
+++ b/tests/test_git_changelog.py
@@ -134,6 +134,61 @@ class TestWithRepository(ChangelogTestCase):
             'more info</literal_block>'
         )
 
+    def test_single_commit_rst_style_detail_lines(self):
+        self.repo.index.commit(
+            'my root commit\n\nadditional information\n\n'
+            '* item1: **description1**\n'
+            '* item2: *description2*'
+        )
+        self.changelog.options.update({'detailed-message-style': 'rst'})
+
+        def handle_nested_parse(lines, offset, node):
+            from docutils import nodes
+            node.append(nodes.paragraph(text='additional information'))
+            bullet_list = nodes.bullet_list()
+            p = nodes.paragraph(
+                '', 'item1: ', nodes.strong(text='description1'))
+            bullet_list.append(nodes.list_item('', p))
+            p = nodes.paragraph(
+                '', 'item2: ', nodes.emphasis(text='description2'))
+            bullet_list.append(nodes.list_item('', p))
+            node.append(bullet_list)
+
+        self.changelog.state.nested_parse.side_effect = handle_nested_parse
+        nodes = self.changelog.run()
+        list_markup = BeautifulSoup(str(nodes[0]), features='xml')
+        item = list_markup.bullet_list.list_item
+        children = list(item.childGenerator())
+        assert_equal(3, len(children))
+        assert_equal(
+            str(children[1]),
+            '<paragraph>additional information</paragraph>'
+        )
+        assert_equal(
+            str(children[2]),
+            '<bullet_list><list_item>'
+            '<paragraph>item1: <strong>description1</strong></paragraph>'
+            '</list_item><list_item>'
+            '<paragraph>item2: <emphasis>description2</emphasis></paragraph>'
+            '</list_item></bullet_list>'
+        )
+
+    def test_single_commit_pre_style_detail_lines(self):
+        self.repo.index.commit(
+            'my root commit\n\nadditional information\nmore info'
+        )
+        self.changelog.options.update({'detailed-message-style': 'pre'})
+        nodes = self.changelog.run()
+        list_markup = BeautifulSoup(str(nodes[0]), features='xml')
+        item = list_markup.bullet_list.list_item
+        children = list(item.childGenerator())
+        assert_equal(2, len(children))
+        assert_equal(
+            str(children[1]),
+            '<literal_block xml:space="preserve">additional information\n'
+            'more info</literal_block>'
+        )
+
     def test_more_than_ten_commits(self):
         for n in range(15):
             self.repo.index.commit('commit #{0}'.format(n))


### PR DESCRIPTION
This PR enables user to select detailed commit message style.
The list bellow is the selectable styles.

* pre: preformatted text (This is same as detailed-message-pre. Now, detailed-message-pre is deprecated).
* rst: parse messages as reStructuredText and output the result.
* md: parse messages as Markdown and output the result (This requires recommonmark package).
