### PR TITLE
Added commit SHA hex code to list item id attribute.

### DIFF
--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -176,6 +176,7 @@ class GitChangelog(GitDirectiveBase):
                 detailed_message = None
 
             item = nodes.list_item()
+            item.attributes["ids"].append(commit.hexsha)
             par = nodes.paragraph()
             # choose detailed message style by detailed-message-strong option
             if self.options.get('detailed-message-strong', True):


### PR DESCRIPTION
I want to add a link to each commit in my CHANGELOG, so I've decided to include the commit SHA HEX inside `id` attribute of list items. I think that is reasonable.