### PR TITLE
sphinx_git: add 'repo-dir' in option_spec of GitCommitDetail

### DIFF
--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -42,6 +42,7 @@ class GitCommitDetail(GitDirectiveBase):
         'untracked': bool,
         'sha_length': int,
         'no_github_link': bool,
+        'repo-dir': six.text_type,
     }
 
     # pylint: disable=attribute-defined-outside-init


### PR DESCRIPTION
Add 'repo-dir' option in the option_spec of GitCommitDetail class.
GitCommitDetail extends class GitDirectiveBase.  GitDirectiveBase base class checks for 'repo-dir' option, with an environment default.
'repo-dir' option previously is in option_spec of GitChangelog but not of GitCommitDetail.
If 'repo-dir' option is added to the option_spec, that option becomes functional for GitCommitDetail because the option is queried in GitDirectiveBase.

1 use of 'repo-dir' option with GitCommitDetail is to embed the git revision (by commit SHA) of a neighboring git repository which is documented by the Sphinx documents, importing doxygen comments from that neighboring git repository by Breathe extension.