### PR TITLE
Add path, no_merges and first_parent options

### DIFF
--- a/docs/using.rst
+++ b/docs/using.rst
@@ -78,8 +78,23 @@ will accept.  See `the man page`_ for details.
 
     Sphinx will output a warning if you specify both.
 
-Filter Revisons to Matching Only Certain Files Based on Filenames
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Filter Revisions to Match Only a Single Directory or File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you only want to see the changelog regarding to a certain directory or file
+you can use the ``:path:`` argument with ``git_changelog``.
+``:path:`` expects a path to the directory or file you want to filter on, either
+as an absolute path or as a relative path from the working directory. So::
+
+    .. git_changelog::
+        :path: doc/
+
+will show all commits that modified files in the ``doc/`` directory.
+
+
+Filter Revisions to Matching Only Certain Files Based on Filenames
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you only want to see the changelog regarding certain files (eg. for devops
 reasons you need to have both SaSS and CSS in your repository or you only want
@@ -156,6 +171,32 @@ for example:
 
     .. git_changelog::
         :detailed-message-strong: False
+
+
+Hiding merge commits
+~~~~~~~~~~~~~~~~~~~~
+
+If you want to hide merge commits from the changelog,
+then you can add the ``:no_merges:`` argument. So::
+
+    .. git_changelog::
+        :no_merges:
+
+will hide all commits that have more than one parent.
+
+
+Showing only the first parent commits
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want the changelog to only display the first parents of commits
+(e.g. your main branch has been merged into a lot and you don't want to
+see the individual commits that came from other branches), then you can
+add the ``:first_parent:`` argument. So::
+
+    .. git_changelog::
+        :first_parent:
+
+will only show the first parent of merge commits.
 
 
 git_commit_detail Directive

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -120,6 +120,8 @@ class GitChangelog(GitDirectiveBase):
         'hide_details': bool,
         'repo-dir': six.text_type,
         'path': directives.path,
+        'first_parent': bool,
+        'no_merges': bool,
     }
 
     def run(self):
@@ -139,9 +141,14 @@ class GitChangelog(GitDirectiveBase):
         return commits
 
     def _filter_commits(self, repo):
+        first_parent = 'first_parent' in self.options
+        no_merges = 'no_merges' in self.options
+
         commits = repo.iter_commits(
             rev=self.options.get('rev-list', None),
             paths=self.options.get('path', ''),
+            first_parent=first_parent,
+            no_merges=no_merges,
         )
         if 'rev-list' not in self.options:
             revisions_to_display = self.options.get('revisions', 10)

--- a/sphinx_git/__init__.py
+++ b/sphinx_git/__init__.py
@@ -119,6 +119,7 @@ class GitChangelog(GitDirectiveBase):
         'hide_date': bool,
         'hide_details': bool,
         'repo-dir': six.text_type,
+        'path': directives.path,
     }
 
     def run(self):
@@ -138,10 +139,11 @@ class GitChangelog(GitDirectiveBase):
         return commits
 
     def _filter_commits(self, repo):
-        if 'rev-list' in self.options:
-            commits = repo.iter_commits(rev=self.options['rev-list'])
-        else:
-            commits = repo.iter_commits()
+        commits = repo.iter_commits(
+            rev=self.options.get('rev-list', None),
+            paths=self.options.get('path', ''),
+        )
+        if 'rev-list' not in self.options:
             revisions_to_display = self.options.get('revisions', 10)
             commits = list(commits)[:revisions_to_display]
         if 'filename_filter' in self.options:


### PR DESCRIPTION
Added path, no_merges and first_parent options.

`path` will filter commits that apply to a specific directory or file. I have noticed my build slowing down when using filename_filter on a sufficiently large repository. The use case I need it for is simple enough that I don't need to use a regex. The new path option will leverage the path name filtering that is already present in git through GitPython instead of regex.

`no_merges` and `first_parent` will hide merge commits and hide the second parent of merge commits respectively. Their names and functionality are directly analogous to the --no-merges and --first-parent options in git commands.